### PR TITLE
improved download method - now always uses proxy from the Java system properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,12 +13,12 @@ repositories {
 }
 
 dependencies {
-    compile gradleApi()    
-    compile "org.codehaus.groovy.modules.http-builder:http-builder:0.7.2"
+    compile gradleApi()
+    compile "de.undercouch:gradle-download-task:3.1.1"
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '2.4'
+    gradleVersion = '2.14.1'
 }
 
 jar {
@@ -65,10 +65,16 @@ def configurePom(def pom) {
         }
 
         developers {
-            developer {
-                id 'leontebbens'
-                name 'Leon Tebbens'
-            }
+            [
+                    developer {
+                        id 'leontebbens'
+                        name 'Leon Tebbens'
+                    },
+                    developer {
+                        id 'amirkibbar'
+                        name 'Amir Kibbar'
+                    }
+            ]
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 #Updated secret and key with server message: Generated key 'MacBookLT.local' for 'leontebbens'
 #Wed, 08 Jul 2015 20:06:22 +0200
 group=eu.leontebbens.gradle
-version=1.3
+version=1.4-SNAPSHOT
 
 gradle.publish.key=30LOAJR8Pj8Df75eAX8os41mv2UTE4d6
 gradle.publish.secret=jQaVh7YnIa1SvWbAeHihNh3nkd4jnMZ4

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat May 23 21:00:16 CEST 2015
+#Tue Aug 09 12:02:22 PDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-all.zip

--- a/src/main/groovy/eu/leontebbens/gradle/ChromedriverUpdaterTask.groovy
+++ b/src/main/groovy/eu/leontebbens/gradle/ChromedriverUpdaterTask.groovy
@@ -1,25 +1,23 @@
 package eu.leontebbens.gradle
 
-import groovyx.net.http.HTTPBuilder
+import de.undercouch.gradle.tasks.download.DownloadAction
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
-
-import java.util.zip.ZipInputStream
-
-import static groovyx.net.http.ContentType.TEXT
-import static groovyx.net.http.Method.GET
 
 class ChromedriverUpdaterTask extends DefaultTask {
     def checkOnly = false
     def latestVersion = "unknown"
     def localVersion = "unknown"
     def chromedriverSiteUrl = "http://chromedriver.storage.googleapis.com"
+    def targetDir = "${project.buildDir}/chromedriver"
+    def LOCAL_VER = "$targetDir/LOCAL_VERSION"
 
     ChromedriverUpdaterTask() {
         setGroup("Build")
         setDescription("Checks the latest release of the selenium chromedriver files on the googlecode website. And downloads them when a new release is available")
     }
 
+    @SuppressWarnings("GroovyUnusedDeclaration")
     @TaskAction
     def chromedriverAction() {
         latestVersion = getLatestVersion();
@@ -44,54 +42,29 @@ class ChromedriverUpdaterTask extends DefaultTask {
             println("Great! Your Chromedriver is already up to date (version $localVersion)")
         } else {
             def latestDriverBaseUrl = "$chromedriverSiteUrl/$latestVersion"
-            println("Downloading Chromedriver $latestVersion from $chromedriverSiteUrl ...")
+
             new File(project.buildDir.toString()).mkdir()
-            downloadFile("$chromedriverSiteUrl/LATEST_RELEASE", "${project.buildDir}/LATEST_RELEASE")
-            downloadAndUnzip("$latestDriverBaseUrl/chromedriver_mac32.zip", "${project.buildDir}/mac")
-            downloadAndUnzip("$latestDriverBaseUrl/chromedriver_win32.zip", "${project.buildDir}/win")
-            downloadAndUnzip("$latestDriverBaseUrl/chromedriver_linux64.zip", "${project.buildDir}/linux")
-            println("Download complete: the latest Chromedriver is available in ${project.buildDir}")
+            downloadFile("$chromedriverSiteUrl/LATEST_RELEASE", LOCAL_VER)
+            downloadAndUnzip("$latestDriverBaseUrl", "chromedriver_mac32.zip", "$targetDir/mac")
+            downloadAndUnzip("$latestDriverBaseUrl", "chromedriver_win32.zip", "$targetDir/win")
+            downloadAndUnzip("$latestDriverBaseUrl", "chromedriver_linux64.zip", "$targetDir/linux")
+            println("Download complete: the latest Chromedriver is available in $targetDir")
         }
     }
 
     private String getLatestVersion() {
-        def versionFileUrl = "$chromedriverSiteUrl/LATEST_RELEASE"
-        def ver = ""
-        getLogger().info("Reading file $versionFileUrl")
-        try {
-            def http = new HTTPBuilder(versionFileUrl)
-            def httpProxyHost = System.properties.'http.proxyHost'
-            def httpProxyPort = System.properties.'http.proxyPort'
-            if (httpProxyHost == null || httpProxyPort == null)
-                getLogger().info("not using http-proxy because -Dhttp.proxyHost and -Dhttp.proxyPort are not defined")
-            else {
-                getLogger().info("using http proxy " + httpProxyHost + ":" + httpProxyPort)
-                http.setProxy(httpProxyHost, httpProxyPort as int, 'http')
-            }
-
-            http.request(GET, TEXT) { req ->
-                headers.'User-Agent' = 'GroovyHTTPBuilder/1.0'
-                response.success = { resp, reader ->
-                    ver = reader.text.trim()
-                    logger.info("Latest available Chromedriver version is $ver")
-                }
-                response.failure = { resp ->
-                    getLogger().error("Error reading file $versionFileUrl")
-                }
-            }
-        } catch (e) {
-            getLogger().error("Error reading file", e)
-        }
-        ver
+        def target = new File("$targetDir/LATEST_RELEASE")
+        downloadFile("$chromedriverSiteUrl/LATEST_RELEASE", target)
+        return target.text.trim()
     }
 
     private String getLocalVersion() {
         def ver = ""
 
         try {
-            def file = new File("${project.buildDir}/LATEST_RELEASE")
+            def file = new File(LOCAL_VER)
             if (file.exists()) {
-                ver = file.text
+                ver = file.text.trim()
                 logger.info("Local Chromedriver version is $ver")
             }
         } catch (e) {
@@ -100,33 +73,23 @@ class ChromedriverUpdaterTask extends DefaultTask {
         ver
     }
 
-    private void downloadFile(def remoteUrl, def localUrl) {
-        def file = new FileOutputStream(localUrl)
-        def out = new BufferedOutputStream(file)
-        out << new URL(remoteUrl).openStream()
-        out.close()
+    private void downloadFile(def remoteUrl, def target) {
+        println "Downloading $remoteUrl to $target"
+        DownloadAction da = new DownloadAction(project)
+        da.dest(target)
+        da.src(remoteUrl)
+        da.onlyIfNewer(true)
+        try {
+            da.execute()
+        } catch (Exception e) {
+            getLogger().error("unable to download $remoteUrl, ${e.getMessage()}")
+            throw e
+        }
     }
 
-    private void downloadAndUnzip(def remoteZipURL, def localDir) {
-        def zipEntry
-        String fileContent = (remoteZipURL).toURL().withInputStream { s ->
-            new ZipInputStream(s).with { zipStream ->
-                new StringWriter().with { stringWriter ->
-                    while (zipEntry = zipStream.nextEntry) {
-                        if (zipEntry.name.startsWith('chromedriver')) {
-                            stringWriter << zipStream
-                            break
-                        }
-                        zipStream.closeEntry()
-                    }
-                    stringWriter.toString()
-                }
-            }
-        }
-        new File(localDir).mkdir()
-        def file = new FileOutputStream("$localDir/${zipEntry.name}")
-        def out = new BufferedOutputStream(file)
-        out << fileContent
-        out.close()
+    private void downloadAndUnzip(def remoteZipURL, def zipName, String localDir) {
+        downloadFile("$remoteZipURL/$zipName", "$targetDir/zipName")
+        new File(localDir).mkdirs()
+        new AntBuilder().unzip(src: "$targetDir/zipName", dest: localDir)
     }
 }


### PR DESCRIPTION
this pull requests solves issue #4 and also improves the way the files are downloaded by using the [gradle download task](https://github.com/michel-kraemer/gradle-download-task) instead of directly downloading the files.

@leontebbens if you want to merge this pull request then don't forget to bump the version number in the gradle.properties, I left it as 1.4-SNAPSHOT