### PR TITLE
The chromedriver project provides AARM64 (Apple Silicon/Apple M1 [Pro…

### DIFF
--- a/src/main/groovy/eu/leontebbens/gradle/ChromedriverUpdaterTask.groovy
+++ b/src/main/groovy/eu/leontebbens/gradle/ChromedriverUpdaterTask.groovy
@@ -81,8 +81,17 @@ class ChromedriverUpdaterTask extends DefaultTask {
             downloadFile(getLatestReleaseDownloadUrl(), LOCAL_VER)
             def arch = calcArch()
             def bit = arch.equals('win') ? '32' : '64'
-            downloadAndUnzip("$latestDriverBaseUrl", "chromedriver_${arch}${bit}.zip", "$targetDir/${arch}")
+            def osArchSuffix = getOsArchDependentSuffix(arch)
+            downloadAndUnzip("$latestDriverBaseUrl", "chromedriver_${arch}${bit}${osArchSuffix}.zip", "$targetDir/${arch}")
             println("Download complete: the latest Chromedriver is available in $targetDir")
+        }
+    }
+
+    private String getOsArchDependentSuffix(String arch) {
+        if (arch == "mac" && System.getProperty("os.arch") == "aarch64") {
+            return "_m1"
+        } else {
+            return ""
         }
     }
 


### PR DESCRIPTION
The chromedriver project provides AARM64 (Apple Silicon/Apple M1 [Pro|Max]) versions of chromedriver. 

If chromedriver runs on a AARM64 mac, it should use this version to avoid the performance penalty caused by Rosetta 2. Otherwise, chromedriver and Chrome are executed in x86_64 mode.

References:
https://github.com/titusfortner/webdrivers/issues/191
https://bugs.chromium.org/p/chromedriver/issues/detail?id=3688